### PR TITLE
replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/blacklist.js
+++ b/scripts/blacklist.js
@@ -126,8 +126,8 @@ function onAddItem(row) {
 		itemToAdd = itemToAdd.replace(/"$/, '\'');
 
 		if (
-			(itemToAdd.substr(0, 1) === '/') &&
-			(itemToAdd.substr(itemToAdd.length -1, 1) === '/')
+			(itemToAdd.slice(0, 1) === '/') &&
+			(itemToAdd.slice(-1) === '/')
 		) {
 
 			try {

--- a/scripts/directory.js
+++ b/scripts/directory.js
@@ -1254,8 +1254,8 @@
 
 					if (title.length === 0) { continue; }
 
-					let firstChar = title.substr(0, 1);
-					let lastChar  = title.substr(title.length -1, 1);
+					let firstChar = title.slice(0, 1);
+					let lastChar  = title.slice(-1);
 
 					// exact match
 					if ((firstChar === '\'') && (lastChar === '\'')) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.