### PR TITLE
Fix sidebar observer

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -215,6 +215,37 @@ async function storageClear() {
 	return error;
 }
 
+/**
+ * Wait (async) the html element requested by selector
+ */
+function waitForElement(selector) {
+	return new Promise((resolve) => {
+		const element = document.querySelector(selector);
+		if (element) {
+			resolve(element);
+			return element;
+		}
+
+		const observer = new MutationObserver((mutationsList, obs) => {
+			for (const mutation of mutationsList) {
+				if (mutation.type === 'childList') {
+					const targetElement = document.querySelector(selector);
+					if (targetElement) {
+						resolve(targetElement);
+						obs.disconnect();
+						break;
+					}
+				}
+			}
+		});
+
+		observer.observe(document.body, {
+			childList: true,
+			subtree: true
+		});
+	})
+}
+
 function logTrace() {
 
 	if (debug > 0) { return null; }

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -243,7 +243,7 @@ function waitForElement(selector) {
 			childList: true,
 			subtree: true
 		});
-	})
+	});
 }
 
 function logTrace() {

--- a/scripts/directory.js
+++ b/scripts/directory.js
@@ -344,7 +344,7 @@
 		const observerCooldown = 500;
 
 		const targetSelector = '[data-a-target^="side-nav-bar"]';
-        const target = await waitForElement(targetSelector)
+        const target = await waitForElement(targetSelector);
 
 		if (target !== null) {
 

--- a/scripts/directory.js
+++ b/scripts/directory.js
@@ -338,13 +338,13 @@
 	/**
 	 * Attaches an observer to the sidebar of the current page, which will filter its items.
 	 */
-	function observeSidebar() {
+	async function observeSidebar() {
 		logTrace('invoking observeSidebar()');
 
 		const observerCooldown = 500;
 
 		const targetSelector = '[data-a-target^="side-nav-bar"]';
-		const target         = rootNode.querySelector(targetSelector);
+        const target = await waitForElement(targetSelector)
 
 		if (target !== null) {
 


### PR DESCRIPTION
fix: wait for sidebar before applying filters

When opening a Twitch channel in a new tab (or refreshing a tab), the sidebar is not yet present in the DOM, preventing filters from being applied.

Added the `waitForElement` function to ensure the sidebar is present before applying filters.